### PR TITLE
Add a link to a new post for 2024 April Cools

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,3 +1,8 @@
+- date: 2024-04-01
+  link: "https://predr.ag/blog/wifi-only-works-when-its-raining/"
+  title: "The WiFi only works when it's raining"
+  abstract: "The strangest hardware problem I've ever had to debug."
+  author: Predrag Gruevski
 - date: 2023-04-01
   link: "https://ttto.cafe/tofu"
   title: "100 Incredible Tofu Recipes"


### PR DESCRIPTION
Consider this a "forward-looking link" — it doesn't work right now, but it will on April 1st when I hit the publish button :)

A link to the draft is available in our Discord, if you'd like to check it out before publishing.