### PR TITLE
Add my April Cools 2024 post

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,3 +1,8 @@
+- date: 2024-04-01
+  link: "https://blog.rtwilson.com/some-easy-recipes/"
+  title: "Some easy recipes"
+  abstract: "Some quick and easy recipes that my family like eating"
+  author: Robin Wilson
 - date: 2023-04-01
   link: "https://ttto.cafe/tofu"
   title: "100 Incredible Tofu Recipes"


### PR DESCRIPTION
This PR adds my April Cools 2024 post. It isn't published yet, but the link should start working early on 1st April 2024.