### PR TITLE
Peter’s post about egg mayo sandwiches

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,3 +1,8 @@
+- date: 2025-04-01
+  link: "https://hilton.org.uk/blog/egg-mayo-sandwich"
+  title: "Egg mayo sandwich optimisation"
+  abstract: "How to minimise time-to-sandwich in the kitchen"
+  author: Peter Hilton
 - date: 2024-04-01
   link: https://davi.sh/blog/2024/04/dune/
   title: "The Spice Didn't Always Flow"


### PR DESCRIPTION
Note: https://hilton.org.uk/ currently has an expired certificate, which I think is caused by a GitHub Pages DNS configuration issue that prevents automatic LetsEncrypt certificate renewal. I’m waiting for a DNS update.